### PR TITLE
Add .NET 8 support

### DIFF
--- a/csharp/PythonNetStubTool/PythonNetStubGenerator.Tool.csproj
+++ b/csharp/PythonNetStubTool/PythonNetStubGenerator.Tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
I realise this is a laughably small PR, but I'm mainly submitting it to hopefully save you some time in regards to the information I'm writing here. I figured since I did this for my own use-case anyway, I may as well give something back. In saying that, thank you for your work on this tool, it has now helped me immensely and it's greatly appreciated.

I have changed the `PythonNetStubGenerator.Tool` project to target multiple frameworks so as not to drop .NET 6 support if it's needed, and have added .NET 8 as an extra target. I am uncertain that it needs to continue targeting .NET 6 to be able to generate stubs for .NET 6 libraries, but I would assume so. I have however tested with a .NET 8 DLL and it works great.

One issue I ran into with my .NET 8 library was that it failed to find `System.Drawing.Common` since that was removed in .NET 7 if I recall correctly. I think this was missing from my debug folder (where I generated the stubs from) since it builds as framework-dependent, because I noticed `System.Drawing.Common.dll` is there in the same folder when I publish the application. Not an issue since I could just run the stub generator against the self-contained publish build, but something to keep in mind if you run into a similar problem or wish to support framework-dependent builds. I'd be happy to add something to the README or documentation about this point if you'd like.

You also updated the README 5 months ago stating that you'd like help making this repository something you could be proud of. I'm more of a senior developer than an intermediate, but I'd be more than willing to help nonetheless if you still want someone to work on this with you. Just let me know if so and we can get in contact.