### PR TITLE
Reorganise projects

### DIFF
--- a/csharp/PythonNetStubGenerator.sln
+++ b/csharp/PythonNetStubGenerator.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PythonNetStubGenerator", "P
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PythonNetStubGenerator.Tool", "PythonNetStubTool\PythonNetStubGenerator.Tool.csproj", "{F62F1E52-9925-4674-B2CE-BE083D848C6C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PythonNetStubTask", "PythonNetStubTask\PythonNetStubTask.csproj", "{D3837FC3-5D4C-4C63-9B94-EBC290E68893}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{F62F1E52-9925-4674-B2CE-BE083D848C6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F62F1E52-9925-4674-B2CE-BE083D848C6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F62F1E52-9925-4674-B2CE-BE083D848C6C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D3837FC3-5D4C-4C63-9B94-EBC290E68893}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D3837FC3-5D4C-4C63-9B94-EBC290E68893}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D3837FC3-5D4C-4C63-9B94-EBC290E68893}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D3837FC3-5D4C-4C63-9B94-EBC290E68893}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/csharp/PythonNetStubGenerator/PythonNetStubGenerator.csproj
+++ b/csharp/PythonNetStubGenerator/PythonNetStubGenerator.csproj
@@ -27,8 +27,4 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.1.0" />
-  </ItemGroup>
-
 </Project>

--- a/csharp/PythonNetStubTask/PythonNetStubTask.cs
+++ b/csharp/PythonNetStubTask/PythonNetStubTask.cs
@@ -1,12 +1,13 @@
-﻿using System;
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using PythonNetStubGenerator;
+using System;
 using System.IO;
 using System.Linq;
-using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 
-namespace PythonNetStubGenerator
+namespace PythonNetStubTask
 {
-    public class PythonStubTask : Task
+    public class PythonNetStubTask : Task
     {
         [Required]
         public string DestPath { get; set; }

--- a/csharp/PythonNetStubTask/PythonNetStubTask.csproj
+++ b/csharp/PythonNetStubTask/PythonNetStubTask.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.3" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\PythonNetStubGenerator\PythonNetStubGenerator.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/csharp/PythonNetStubTool/PythonNetStubGenerator.Tool.csproj
+++ b/csharp/PythonNetStubTool/PythonNetStubGenerator.Tool.csproj
@@ -20,6 +20,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="nupkg\**" />
+    <EmbeddedResource Remove="nupkg\**" />
+    <None Remove="nupkg\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\..\README.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>


### PR DESCRIPTION
### Digest of changes

* Separate `PythonStubTask` from `PythonNetStubGenerator`
* Rename `PythonStubTask` `PythonNetStubTask`
* Trivial changes

### Notes

More PRs will follow to [fix some existing bugs](https://github.com/petcg/pythonnet-stub-generator/pull/2) and [modernise .NET runtime and packages](https://github.com/petcg/pythonnet-stub-generator/pull/5).
